### PR TITLE
paths will be set to current working directory if not set in .spc file.

### DIFF
--- a/csv/plugin.go
+++ b/csv/plugin.go
@@ -54,8 +54,9 @@ func csvList(ctx context.Context, p *plugin.Plugin) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// Glob paths in config
-	// set current working directory if no paths are specified
+	// set current working directory as default path if no paths are specified
 	csvConfig := GetConfig(p.Connection)
 	if &csvConfig == nil || csvConfig.Paths == nil {
 		paths = append(paths, cwd+"/*")

--- a/csv/plugin.go
+++ b/csv/plugin.go
@@ -2,7 +2,6 @@ package csv
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,12 +47,20 @@ func PluginTables(ctx context.Context, p *plugin.Plugin) (map[string]*plugin.Tab
 func csvList(ctx context.Context, p *plugin.Plugin) ([]string, error) {
 
 	var csvFilePaths []string
+	var paths []string
 
+	// fetch current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
 	// Glob paths in config
-	// Fail if no paths are specified
+	// set current working directory if no paths are specified
 	csvConfig := GetConfig(p.Connection)
 	if &csvConfig == nil || csvConfig.Paths == nil {
-		return csvFilePaths, errors.New("paths must be configured")
+		paths = append(paths, cwd+"/*")
+	} else {
+		paths = csvConfig.Paths
 	}
 
 	// File system context
@@ -64,7 +71,7 @@ func csvList(ctx context.Context, p *plugin.Plugin) ([]string, error) {
 
 	// Gather file path matches for the glob
 	var matches []string
-	paths := csvConfig.Paths
+
 	for _, i := range paths {
 
 		// Resolve ~ to home dir


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
➜  steampipe-plugin-csv git:(main) ✗ steampipe plugin list
+-------------------------------------------------------+---------+----------------+
| Name                                                  | Version | Connections    |
+-------------------------------------------------------+---------+----------------+
| hub.steampipe.io/plugins/turbot/alicloud@latest       | local   |                |
| hub.steampipe.io/plugins/turbot/aws@latest            | local   | aws,aws_sso    |
| hub.steampipe.io/plugins/turbot/azure@latest          | 0.21.1  | azure          |
| hub.steampipe.io/plugins/turbot/azuread@latest        | 0.1.0   | azuread        |
| hub.steampipe.io/plugins/turbot/cloudflare@latest     | 0.2.0   | cloudflare     |
| hub.steampipe.io/plugins/turbot/csv@latest            | 0.1.0   |                |
| hub.steampipe.io/plugins/turbot/digitalocean@latest   | 0.6.0   | digitalocean   |
| hub.steampipe.io/plugins/turbot/gcp@latest            | local   | gcp            |
| hub.steampipe.io/plugins/turbot/github@latest         | 0.10.0  | github         |
| hub.steampipe.io/plugins/turbot/ibm@latest            | 0.0.3   | ibm            |
| hub.steampipe.io/plugins/turbot/kubernetes@latest     | local   | kubernetes     |
| hub.steampipe.io/plugins/turbot/oci@latest            | local   | oci            |
| hub.steampipe.io/plugins/turbot/steampipe@latest      | local   |                |
| hub.steampipe.io/plugins/turbot/steampipecloud@latest | local   | steampipecloud |
| hub.steampipe.io/plugins/turbot/stripe@latest         | 0.1.0   | stripe         |
| hub.steampipe.io/plugins/turbot/zendesk@latest        | 0.3.0   | zendesk        |
+-------------------------------------------------------+---------+----------------+
```
</details>
