### PR TITLE
Update plugin to discover all the CSV files present in CWD by default. Closes #13

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - amd64
       - arm64
     ignore:
-      - goos: darwin # docs suggest that darwin arm64 should compile, but doesnt...
+      - goos: darwin # docs suggest that darwin arm64 should compile, but doesn't...
         goarch: arm64
 
     id: "steampipe-csv"

--- a/README.md
+++ b/README.md
@@ -17,13 +17,12 @@ Install the plugin with [Steampipe](https://steampipe.io):
 steampipe plugin install csv
 ```
 
-Configure the paths to your CSV files in `~/.steampipe/config/csv.spc`:
+Configure your [config file](https://hub.steampipe.io/plugins/turbot/csv#configuration) to include directories with CSV files. If no directory is specified, the current working directory will be used.
 
-```hcl
-connection "csv" {
-  plugin = "csv"
-  paths  = [ "/path/to/your/files/*.csv" ]
-}
+Run steampipe:
+
+```shell
+steampipe query
 ```
 
 Run a query for the `my_users.csv` file:
@@ -33,7 +32,7 @@ select
   first_name,
   last_name
 from
-  my_users
+  my_users;
 ```
 
 ## Developing

--- a/config/csv.spc
+++ b/config/csv.spc
@@ -1,12 +1,23 @@
 connection "csv" {
   plugin = "csv"
 
-  # Paths is a list of locations to search for CSV files. Each file will be
-  # converted to a table. Wildcards are supported per
-  # https://golang.org/pkg/path/filepath/#Match
-  # Exact file paths can have any name. Wildcard based matches must have an
-  # extension of .csv (case insensitive).
-  # paths = [ "/path/to/dir/*", "/path/to/exact/custom.csv" ]
+  # Paths is a list of locations to search for CSV files
+  # All paths are resolved relative to the current working directory (CWD)
+  # Wildcard based searches are supported, including recursive searches
+
+  # For example:
+  #  - "*.csv" matches all CSV files in the CWD
+  #  - "**/*.csv" matches all CSV files in the CWD and all sub-directories
+  #  - "../*.csv" matches all CSV files in the CWD's parent directory
+  #  - "steampipe*.csv" matches all CSV files starting with "steampipe" in the current CWD
+  #  - "/path/to/dir/*.csv" matches all CSV files in a specific directory
+  #  - "/path/to/dir/custom.csv" matches a specific file
+
+  # If paths includes "*", all files (including non-CSV files) in
+  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+
+  # Defaults to CWD
+  paths = [ "*.csv" ]
 
   # The field delimiter character when parsing CSV files. Must be a single
   # character. Defaults to comma.

--- a/config/csv.spc
+++ b/config/csv.spc
@@ -9,12 +9,12 @@ connection "csv" {
   #  - "*.csv" matches all CSV files in the CWD
   #  - "**/*.csv" matches all CSV files in the CWD and all sub-directories
   #  - "../*.csv" matches all CSV files in the CWD's parent directory
-  #  - "steampipe*.csv" matches all CSV files starting with "steampipe" in the current CWD
+  #  - "steampipe*.csv" matches all CSV files starting with "steampipe" in the CWD
   #  - "/path/to/dir/*.csv" matches all CSV files in a specific directory
   #  - "/path/to/dir/custom.csv" matches a specific file
 
   # If paths includes "*", all files (including non-CSV files) in
-  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+  # the CWD will be matched, which may cause errors if incompatible file types exist
 
   # Defaults to CWD
   paths = [ "*.csv" ]

--- a/csv/plugin.go
+++ b/csv/plugin.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bmatcuk/doublestar"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 )
@@ -27,7 +28,6 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 }
 
 func PluginTables(ctx context.Context, p *plugin.Plugin) (map[string]*plugin.Table, error) {
-
 	// Initialize tables
 	tables := map[string]*plugin.Table{}
 
@@ -50,48 +50,65 @@ func PluginTables(ctx context.Context, p *plugin.Plugin) (map[string]*plugin.Tab
 }
 
 func csvList(ctx context.Context, p *plugin.Plugin) ([]string, error) {
-
-	var csvFilePaths []string
-
 	// Glob paths in config
 	// Fail if no paths are specified
 	csvConfig := GetConfig(p.Connection)
-	if &csvConfig == nil || csvConfig.Paths == nil {
-		return csvFilePaths, errors.New("paths must be configured")
-	}
-
-	// File system context
-	home, err := os.UserHomeDir()
-	if err != nil {
-		plugin.Logger(ctx).Error("csv.csvList", "os.UserHomeDir error. ~ will not be expanded in paths.", err)
+	if csvConfig.Paths == nil {
+		return nil, errors.New("paths must be configured")
 	}
 
 	// Gather file path matches for the glob
 	var matches []string
 	paths := csvConfig.Paths
 	for _, i := range paths {
+		// Check to resolve ~ to home dir
+		if strings.HasPrefix(i, "~") {
+			// File system context
+			home, err := os.UserHomeDir()
+			if err != nil {
+				plugin.Logger(ctx).Error("csv.csvList", "os.UserHomeDir error. ~ will not be expanded in paths.", err)
+			}
 
-		// Resolve ~ to home dir
-		if home != "" {
-			if i == "~" {
-				i = home
-			} else if strings.HasPrefix(i, "~/") {
-				i = filepath.Join(home, i[2:])
+			// Resolve ~ to home dir
+			if home != "" {
+				if i == "~" {
+					i = home
+				} else if strings.HasPrefix(i, "~/") {
+					i = filepath.Join(home, i[2:])
+				}
 			}
 		}
 
-		// Expand globs
-		iMatches, err := filepath.Glob(i)
+		// Get full path
+		fullPath, err := filepath.Abs(i)
 		if err != nil {
-			// Fail if any path is an invalid glob
-			return matches, fmt.Errorf("path is not a valid glob: %s", i)
+			plugin.Logger(ctx).Error("csv.csvList", "failed to fetch absolute path", err, "path", i)
+			return nil, err
 		}
 
+		// Expand globs
+		iMatches, err := doublestar.Glob(fullPath)
+		if err != nil {
+			// Fail if any path is an invalid glob
+			return nil, fmt.Errorf("Path is not a valid glob: %s", i)
+		}
 		matches = append(matches, iMatches...)
 	}
 
 	// Sanitize the matches to likely csvfiles
+	var csvFilePaths []string
 	for _, i := range matches {
+		// Check if file or directory
+		fileInfo, err := os.Stat(i)
+		if err != nil {
+			plugin.Logger(ctx).Error("utils.tfConfigList", "error getting file info", err, "path", i)
+			return nil, err
+		}
+
+		// Ignore directories
+		if fileInfo.IsDir() {
+			continue
+		}
 
 		// If the file path is an exact match to a matrix path then it's always
 		// treated as a match - it was requested exactly
@@ -106,13 +123,7 @@ func csvList(ctx context.Context, p *plugin.Plugin) ([]string, error) {
 			csvFilePaths = append(csvFilePaths, i)
 			continue
 		}
-
-		// This file was expanded from the glob, so check it's likely to be
-		// of the right type based on the name / extension.
-		ext := strings.ToLower(filepath.Ext(i))
-		if ext == ".csv" {
-			csvFilePaths = append(csvFilePaths, i)
-		}
+		csvFilePaths = append(csvFilePaths, i)
 	}
 
 	return csvFilePaths, nil

--- a/csv/table_code_csv.go
+++ b/csv/table_code_csv.go
@@ -41,7 +41,7 @@ func tableCSV(ctx context.Context, p *plugin.Plugin) (*plugin.Table, error) {
 	header, err := r.Read()
 	if err != nil {
 		plugin.Logger(ctx).Error("csv.tableCSV", "header_parse_error", err, "path", path, "header", header)
-		return nil, err
+		return nil, fmt.Errorf("failed to parse file header %s: %v", path, err)
 	}
 
 	cols := []*plugin.Column{}

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ connection "csv" {
 }
 ```
 
-- `paths` - A list of directory paths to search for CSV files. Paths are resolved relative to the current working directory. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match) and also support `**` for recursive matching. Defaults to the current working directory.
+- `paths` - A list of directory paths to search for CSV files. Paths are resolved relative to the current working directory. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match) and also supports `**` for recursive matching. Defaults to the current working directory.
 - `separator` - Field delimiter when parsing files. Defaults to `,`.
 - `comment` - Lines starting with this comment character are ignored. Disabled by default.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,10 +23,10 @@ select
   first_name,
   last_name
 from
-  my_users
+  my_users;
 ```
 
-```
+```sh
 +------------+-----------+
 | first_name | last_name |
 +------------+-----------+
@@ -60,11 +60,36 @@ Installing the latest csv plugin will create a config file (`~/.steampipe/config
 ```hcl
 connection "csv" {
   plugin = "csv"
-  paths  = [ "/path/to/your/files/*.csv" ]
+
+  # Paths is a list of locations to search for CSV files
+  # All paths are resolved relative to the current working directory (CWD)
+  # Wildcard based searches are supported, including recursive searches
+
+  # For example:
+  #  - "*.csv" matches all CSV files in the CWD
+  #  - "**/*.csv" matches all CSV files in the CWD and all sub-directories
+  #  - "../*.csv" matches all CSV files in the CWD's parent directory
+  #  - "steampipe*.csv" matches all CSV files starting with "steampipe" in the current CWD
+  #  - "/path/to/dir/*.csv" matches all CSV files in a specific directory
+  #  - "/path/to/dir/custom.csv" matches a specific file
+
+  # If paths includes "*", all files (including non-CSV files) in
+  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+
+  # Defaults to CWD
+  paths = [ "*.csv" ]
+
+  # The field delimiter character when parsing CSV files. Must be a single
+  # character. Defaults to comma.
+  # separator = ","
+
+  # If set, then lines beginning with the comment character without preceding
+  # whitespace are ignored. Disabled by default.
+  # comment = "#"
 }
 ```
 
-- `paths` - A list of directory paths to search for CSV files. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match). File matches must have the extension `.csv` (case insensitive).
+- `paths` - A list of directory paths to search for CSV files. Paths are resolved relative to the current working directory. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match) and also support `**` for recursive matching. Defaults to the current working directory.
 - `separator` - Field delimiter when parsing files. Defaults to `,`.
 - `comment` - Lines starting with this comment character are ignored. Disabled by default.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,12 +69,12 @@ connection "csv" {
   #  - "*.csv" matches all CSV files in the CWD
   #  - "**/*.csv" matches all CSV files in the CWD and all sub-directories
   #  - "../*.csv" matches all CSV files in the CWD's parent directory
-  #  - "steampipe*.csv" matches all CSV files starting with "steampipe" in the current CWD
+  #  - "steampipe*.csv" matches all CSV files starting with "steampipe" in the CWD
   #  - "/path/to/dir/*.csv" matches all CSV files in a specific directory
   #  - "/path/to/dir/custom.csv" matches a specific file
 
   # If paths includes "*", all files (including non-CSV files) in
-  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+  # the CWD will be matched, which may cause errors if incompatible file types exist
 
   # Defaults to CWD
   paths = [ "*.csv" ]

--- a/docs/tables/{csv_filename}.md
+++ b/docs/tables/{csv_filename}.md
@@ -4,19 +4,22 @@ Query data from CSV files. A table is automatically created to represent each
 CSV file found in the configured `paths`.
 
 For instance, if `paths` is set to `/Users/myuser/csv/*`, and that directory contains:
+
 - products.csv
 - users.csv
 
 This plugin will create 2 tables:
+
 - products
 - users
 
 Which you can then query directly:
+
 ```sql
 select
   *
 from
-  users
+  users;
 ```
 
 Each of these tables will have the same column structure as the CSV they were
@@ -27,6 +30,7 @@ created from and all column values are returned as text data type.
 ### Inspect the table structure
 
 Assuming your connection is called `csv` (the default), list all tables with:
+
 ```sql
 .inspect csv
 +----------+--------------------------------------------+
@@ -38,6 +42,7 @@ Assuming your connection is called `csv` (the default), list all tables with:
 ```
 
 To get defails for a specific table, inspect it by name:
+
 ```sql
 .inspect csv.users
 +------------+------+-------------+
@@ -57,7 +62,7 @@ Given the file `users.csv`, the query is:
 select
   *
 from
-  users
+  users;
 ```
 
 ### Query a complex file name

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/turbot/steampipe-plugin-csv
 
 go 1.17
 
-require github.com/turbot/steampipe-plugin-sdk v1.8.2
+require (
+	github.com/bmatcuk/doublestar v1.3.4
+	github.com/turbot/steampipe-plugin-sdk v1.8.2
+)
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/btubbs/datetime v0.1.1 h1:KuV+F9tyq/hEnezmKZNGk8dzqMVsId6EpFVrQCfA3To=
 github.com/btubbs/datetime v0.1.1/go.mod h1:n2BZ/2ltnRzNiz27aE3wUb2onNttQdC+WFxAoks5jJM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
Updates:
- Update `paths` default to `["*.csv"]`, so CSV files in the current directory are loaded (non-recursively)
- `paths` arg is no longer commented out by default
- Add support for `~` expansion in `paths`
- Add support for `**` to support matching recursively
- Remove file extension matching when using wildcards, e.g., if `paths = [ "*" ]`, files not ending in `.csv` will be loaded as well, which would cause a parsing error
- The plugin will still fail to initialize if `paths` is not defined (as a warning to users)