### PR TITLE
set the default column names for some cases

### DIFF
--- a/config/csv.spc
+++ b/config/csv.spc
@@ -26,4 +26,9 @@ connection "csv" {
   # If set, then lines beginning with the comment character without preceding
   # whitespace are ignored. Disabled by default.
   # comment = "#"
+
+  # When it is "off", the default header is added. If the value is set "auto", 
+  # it is added only if the empty or duplicated value exist in the header.
+  # Defaults to on.
+  # header = "on"
 }

--- a/config/csv.spc
+++ b/config/csv.spc
@@ -30,5 +30,5 @@ connection "csv" {
   # When it is "off", the default header is added. If the value is set "auto", 
   # it is added only if the empty or duplicated value exist in the header.
   # Defaults to on.
-  # header = "on"
+  header = "on"
 }

--- a/csv/connection_config.go
+++ b/csv/connection_config.go
@@ -39,8 +39,8 @@ func GetConfig(connection *plugin.Connection) csvConfig {
 	}
 	config, _ := connection.Config.(csvConfig)
 	if config.Header == nil {
-		on := "on"
-		config.Header = &on
+		defaultValue := "on"
+		config.Header = &defaultValue
 	}
 	return config
 }

--- a/csv/connection_config.go
+++ b/csv/connection_config.go
@@ -9,6 +9,7 @@ type csvConfig struct {
 	Paths     []string `cty:"paths"`
 	Separator *string  `cty:"separator"`
 	Comment   *string  `cty:"comment"`
+	Header    *string  `cty:"header"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
@@ -20,6 +21,9 @@ var ConfigSchema = map[string]*schema.Attribute{
 		Type: schema.TypeString,
 	},
 	"comment": {
+		Type: schema.TypeString,
+	},
+	"header": {
 		Type: schema.TypeString,
 	},
 }
@@ -34,5 +38,9 @@ func GetConfig(connection *plugin.Connection) csvConfig {
 		return csvConfig{}
 	}
 	config, _ := connection.Config.(csvConfig)
+	if config.Header == nil {
+		on := "on"
+		config.Header = &on
+	}
 	return config
 }

--- a/csv/table_code_csv.go
+++ b/csv/table_code_csv.go
@@ -60,6 +60,9 @@ func tableCSV(ctx context.Context, connection *plugin.Connection) (*plugin.Table
 		// Set the default column name
 		if setDefaultHeader {
 			i = fmt.Sprintf("c%d", idx)
+		} else if len(i) == 0 {
+			plugin.Logger(ctx).Error("csv.tableCSV", "empty_header_error", "header row has empty value", "path", path, "field", idx)
+			return nil, fmt.Errorf("%s header row has empty value in field %d", path, idx)
 		}
 		colNames = append(colNames, i)
 		cols = append(cols, &plugin.Column{Name: i, Type: proto.ColumnType_STRING, Transform: transform.FromField(helpers.EscapePropertyName(i)), Description: fmt.Sprintf("Field %d.", idx)})

--- a/csv/table_code_csv.go
+++ b/csv/table_code_csv.go
@@ -76,7 +76,7 @@ func tableCSV(ctx context.Context, connection *plugin.Connection) (*plugin.Table
 	for idx, i := range header {
 		// Set the default column name
 		if !isHeader {
-			i = fmt.Sprintf("_c%d", idx)
+			i = fmt.Sprintf("c%d", idx)
 		}
 		colNames = append(colNames, i)
 		cols = append(cols, &plugin.Column{Name: i, Type: proto.ColumnType_STRING, Transform: transform.FromField(helpers.EscapePropertyName(i)), Description: fmt.Sprintf("Field %d.", idx)})

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ connection "csv" {
   # When it is "off", the default header is added. If the value is set "auto", 
   # it is added only if the empty or duplicated value exist in the header.
   # Defaults to on.
-  # header = "on"
+  header = "on"
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,12 +86,18 @@ connection "csv" {
   # If set, then lines beginning with the comment character without preceding
   # whitespace are ignored. Disabled by default.
   # comment = "#"
+
+  # When it is "off", the default header is added. If the value is set "auto", 
+  # it is added only if the empty or duplicated value exist in the header.
+  # Defaults to on.
+  # header = "on"
 }
 ```
 
 - `paths` - A list of directory paths to search for CSV files. Paths are resolved relative to the current working directory. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match) and also supports `**` for recursive matching. Defaults to the current working directory.
 - `separator` - Field delimiter when parsing files. Defaults to `,`.
 - `comment` - Lines starting with this comment character are ignored. Disabled by default.
+- `header` - Header existance of a CSV file. The default header can be added by set it `off` or `auto`. Defaults to `on`.
 
 ## Get involved
 


### PR DESCRIPTION
If there is no header row, you may want to use the default column names. Of course it is not easy to judge that but, at least we know that there is the case.

1. header row has the empty value
2. header row has the duplicated value

You could add more cases but I am only dealing with those two cases.
I have tested `golangci-lint` at local.

# Example query results
<details>
  <summary>Results</summary>

1.  When header row has the duplicated value,

```
> cat test.csv
a,,b,b,c
1,1,1,1,1
2,2,2,2,2
3,3,3,3,3
4,4,4,4,4
```

the query result is given as follows:
```
> select * from test
+-----+-----+-----+-----+-----+---------------------------+
| _c0 | _c1 | _c2 | _c3 | _c4 | _ctx                      |
+-----+-----+-----+-----+-----+---------------------------+
| 2   | 2   | 2   | 2   | 2   | {"connection_name":"csv"} |
| 4   | 4   | 4   | 4   | 4   | {"connection_name":"csv"} |
| a   |     | b   | b   | c   | {"connection_name":"csv"} |
| 1   | 1   | 1   | 1   | 1   | {"connection_name":"csv"} |
| 3   | 3   | 3   | 3   | 3   | {"connection_name":"csv"} |
+-----+-----+-----+-----+-----+---------------------------+
```

3. When header row has the duplicated value,

```
> cat test.csv
a,a,b,b,c
1,1,1,1,1
2,2,2,2,2
3,3,3,3,3
4,4,4,4,4
```

the query result is given as follows:
```
> select * from test
+-----+-----+-----+-----+-----+---------------------------+
| _c0 | _c1 | _c2 | _c3 | _c4 | _ctx                      |
+-----+-----+-----+-----+-----+---------------------------+
| 3   | 3   | 3   | 3   | 3   | {"connection_name":"csv"} |
| a   | a   | b   | b   | c   | {"connection_name":"csv"} |
| 1   | 1   | 1   | 1   | 1   | {"connection_name":"csv"} |
| 2   | 2   | 2   | 2   | 2   | {"connection_name":"csv"} |
| 4   | 4   | 4   | 4   | 4   | {"connection_name":"csv"} |
+-----+-----+-----+-----+-----+---------------------------+
```
</details>
