### PR TITLE
Set explicit permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     uses: turbot/steampipe-workflows/.github/workflows/assign-issue-to-project.yml@main

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci_lint_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/golangci-lint.yml@main

--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   registry_publish_workflow_ghcr:
     uses: turbot/steampipe-workflows/.github/workflows/registry-publish-ghcr.yml@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,11 @@ on:
         default: "false"
         type: string
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/stale.yml@main

--- a/.github/workflows/steampipe-anywhere.yml
+++ b/.github/workflows/steampipe-anywhere.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
         
 
+permissions:
+  contents: write
+
 jobs:
   anywhere_publish_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/steampipe-anywhere.yml@main

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -4,6 +4,10 @@ on:
     - cron: "30 22 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   sync_labels_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/sync-labels.yml@main


### PR DESCRIPTION
## Harden GitHub Actions workflows

- Add explicit minimal `permissions` blocks to all workflows

**Why**: Explicit permissions follow the principle of least privilege, reducing the blast radius if a workflow is compromised. Each workflow gets only the permissions its reusable workflow requires.